### PR TITLE
Properly encode unicode city to prevent urlencode from blowing up on non...

### DIFF
--- a/city_list.py
+++ b/city_list.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+us = 'Hays, Kansas'
+intl = 'Saint-Pol-de-Léon, Finistère'

--- a/geocodertests.py
+++ b/geocodertests.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+import city_list
 import nominatim
 import unittest
 
@@ -7,7 +9,12 @@ class GeocoderTestCase(unittest.TestCase):
 
     def test_geocode_city(self):
         client = nominatim.Geocoder()
-        response = client.geocode('Hays, Kansas')
+        response = client.geocode(city_list.us)
+        self.assertIsNotNone(response)
+
+    def test_get_location_by_city_invalid_chars(self):
+        client = nominatim.Geocoder()
+        response = client.geocode(unicode(city_list.intl, 'utf-8'))
         self.assertIsNotNone(response)
 
 

--- a/nominatim/geocoder.py
+++ b/nominatim/geocoder.py
@@ -13,6 +13,7 @@ class Geocoder(object):
                  countrycodes='', viewbox=(), exclude_place_ids=[],
                  bounded=False, routewidth=None, osm_type='', osm_id=None):
 
+        q =  unicode(q).encode('utf-8')
         params = { 'q': q }
         params['addressdetails'] = addressdetails
 


### PR DESCRIPTION
...-string values.
